### PR TITLE
Removes string type from HaveCap

### DIFF
--- a/matchers/have_cap.go
+++ b/matchers/have_cap.go
@@ -25,7 +25,7 @@ func (m HaveCapMatcher) Match(actual interface{}) (interface{}, error) {
 	}
 
 	if c != m.expected {
-		return nil, fmt.Errorf("%v (cap=%d) does not have a capacity f %d", actual, c, m.expected)
+		return nil, fmt.Errorf("%v (cap=%d) does not have a capacity %d", actual, c, m.expected)
 	}
 
 	return actual, nil

--- a/matchers/have_cap.go
+++ b/matchers/have_cap.go
@@ -18,10 +18,10 @@ func HaveCap(expected int) HaveCapMatcher {
 func (m HaveCapMatcher) Match(actual interface{}) (interface{}, error) {
 	var c int
 	switch reflect.TypeOf(actual).Kind() {
-	case reflect.Slice, reflect.Array, reflect.Map, reflect.String, reflect.Chan:
+	case reflect.Slice, reflect.Array, reflect.Map, reflect.Chan:
 		c = reflect.ValueOf(actual).Cap()
 	default:
-		return nil, fmt.Errorf("'%v' (%T) is not a Slice, Array, or Channel", actual, actual)
+		return nil, fmt.Errorf("'%v' (%T) is not a Slice, Array, Map or Channel", actual, actual)
 	}
 
 	if c != m.expected {

--- a/matchers/have_cap_test.go
+++ b/matchers/have_cap_test.go
@@ -40,4 +40,9 @@ func TestCap(t *testing.T) {
 	if err == nil {
 		t.Error("expected err to not be nil")
 	}
+
+	_, err = m.Match("some string")
+	if err == nil {
+		t.Error("expected err to not be nil")
+	}
 }


### PR DESCRIPTION
- Since a string doesn't have capacity. [Reference](https://golang.org/pkg/builtin/#cap)

Signed-off-by: Warren Fernandes <warren.f.fernandes@gmail.com>