### PR TITLE
Singular form matchers

### DIFF
--- a/matchers/contain_sub_string.go
+++ b/matchers/contain_sub_string.go
@@ -5,17 +5,17 @@ import (
 	"strings"
 )
 
-type ContainsMatcher struct {
+type ContainSubstringMatcher struct {
 	substr string
 }
 
-func Contains(substr string) ContainsMatcher {
-	return ContainsMatcher{
+func ContainSubstring(substr string) ContainSubstringMatcher {
+	return ContainSubstringMatcher{
 		substr: substr,
 	}
 }
 
-func (m ContainsMatcher) Match(actual interface{}) (interface{}, error) {
+func (m ContainSubstringMatcher) Match(actual interface{}) (interface{}, error) {
 	s, ok := actual.(string)
 	if !ok {
 		return nil, fmt.Errorf("'%v' (%T) is not a string", actual, actual)

--- a/matchers/contain_sub_string_test.go
+++ b/matchers/contain_sub_string_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/apoydence/onpar/matchers"
 )
 
-func TestContains(t *testing.T) {
+func TestContainSubstring(t *testing.T) {
 	t.Parallel()
 
-	m := matchers.Contains("foo")
+	m := matchers.ContainSubstring("foo")
 
 	_, err := m.Match("bar")
 	if err == nil {

--- a/matchers/end_with.go
+++ b/matchers/end_with.go
@@ -5,17 +5,17 @@ import (
 	"strings"
 )
 
-type EndsWithMatcher struct {
+type EndWithMatcher struct {
 	suffix string
 }
 
-func EndsWith(suffix string) EndsWithMatcher {
-	return EndsWithMatcher{
+func EndWith(suffix string) EndWithMatcher {
+	return EndWithMatcher{
 		suffix: suffix,
 	}
 }
 
-func (m EndsWithMatcher) Match(actual interface{}) (interface{}, error) {
+func (m EndWithMatcher) Match(actual interface{}) (interface{}, error) {
 	s, ok := actual.(string)
 	if !ok {
 		return nil, fmt.Errorf("'%v' (%T) is not a string", actual, actual)

--- a/matchers/end_with_test.go
+++ b/matchers/end_with_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/apoydence/onpar/matchers"
 )
 
-func TestEndsWith(t *testing.T) {
+func TestEndWith(t *testing.T) {
 	t.Parallel()
 
-	m := matchers.EndsWith("foo")
+	m := matchers.EndWith("foo")
 
 	_, err := m.Match("bar")
 	if err == nil {

--- a/matchers/start_with.go
+++ b/matchers/start_with.go
@@ -5,17 +5,17 @@ import (
 	"strings"
 )
 
-type StartsWithMatcher struct {
+type StartWithMatcher struct {
 	prefix string
 }
 
-func StartsWith(prefix string) StartsWithMatcher {
-	return StartsWithMatcher{
+func StartWith(prefix string) StartWithMatcher {
+	return StartWithMatcher{
 		prefix: prefix,
 	}
 }
 
-func (m StartsWithMatcher) Match(actual interface{}) (interface{}, error) {
+func (m StartWithMatcher) Match(actual interface{}) (interface{}, error) {
 	s, ok := actual.(string)
 	if !ok {
 		return nil, fmt.Errorf("'%v' (%T) is not a string", actual, actual)

--- a/matchers/start_with_test.go
+++ b/matchers/start_with_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/apoydence/onpar/matchers"
 )
 
-func TestStartsWith(t *testing.T) {
+func TestStartWith(t *testing.T) {
 	t.Parallel()
 
-	m := matchers.StartsWith("foo")
+	m := matchers.StartWith("foo")
 
 	_, err := m.Match("bar")
 	if err == nil {


### PR DESCRIPTION
Simple renaming of matchers for better readability when using with Expect.