### PR TITLE
Matcher docs

### DIFF
--- a/matchers/README.md
+++ b/matchers/README.md
@@ -98,7 +98,7 @@ AlwaysMatcher matches by polling the child matcher until it returns an error.
 It will return an error the first time the child matcher returns an error.
 If the child matcher never returns an error, then it will return a nil.
 
-By default, the duration is 100ms with an interval is 10ms.
+By default, the duration is 100ms with an interval of 10ms.
 
 ```go
 isTrue := func() bool {
@@ -118,9 +118,20 @@ c <- true
 Expect(t, c).To(Receive())
 ```
 
+### BeClosed
+BeClosedMatcher only accepts a readable channel. It will error for anything else.
+It will succeed if the channel is closed.
+
+```go
+c := make(chan bool)
+close(c)
+Expect(t, c).To(BeClosed())
+```
+
 ## Collection Matchers
 ### HaveCap
-This matcher works on Slices, Arrays, Maps and Channels.
+This matcher works on Slices, Arrays, Maps and Channels and will succeed if the
+type has the specified capacity.
 
 ```go
 Expect(t, []string{"foo", "bar"}).To(HaveCap(2))
@@ -135,7 +146,7 @@ Expect(t, fooMap).To(HaveKey("foo"))
 
 ### HaveLen
 HaveLenMatcher accepts Strings, Slices, Arrays, Maps and Channels. It will
-succeed if the type passed has the specified length.
+succeed if the type has the specified length.
 ```go
 Expect(t, "12345").To(HaveLen(5))
 ```

--- a/matchers/README.md
+++ b/matchers/README.md
@@ -86,7 +86,7 @@ Expect(t, 42).To(Equal(42))
 
 ## Error Matchers
 ### HaveOccurred
-HaveOccurredMatcher will succeed for a non-nil error.
+HaveOccurredMatcher will succeed if the actual value is a non-nil error.
 
 ```go
 Expect(t, err).To(HaveOccurred())

--- a/matchers/README.md
+++ b/matchers/README.md
@@ -41,14 +41,14 @@ Expect(t, "foobar").To(ContainSubstring("ooba"))
 
 ## Logical Matchers
 ### Not
-NotMatcher accepts a matcher and will succeed if the passed in matcher fails.
+NotMatcher accepts a matcher and will succeed if the specified matcher fails.
 
 ```go
 Expect(t, false).To(Not(BeTrue()))
 ```
 
 ### BeAbove
-BeAboveMatcher accepts a numerical value. It succeeds of the actual is more
+BeAboveMatcher accepts a numerical value. It succeeds if the actual is greater
 than the expected.
 
 ```go
@@ -64,7 +64,8 @@ Expect(t, 100).To(BeBelow(101))
 ```
 
 ### BeFalse
-BeFalse will succeed if actual is false.
+BeFalseMatcher will succeed if actual is false.
+
 ```go
 Expect(t, 2 == 3).To(BeFalse())
 ```
@@ -86,6 +87,7 @@ Expect(t, 42).To(Equal(42))
 ## Error Matchers
 ### HaveOccurred
 HaveOccurredMatcher will succeed for a non-nil error.
+
 ```go
 Expect(t, err).To(HaveOccurred())
 

--- a/matchers/README.md
+++ b/matchers/README.md
@@ -38,6 +38,7 @@ sub-string of the actual.
 ```go
 Expect(t, "foobar").To(ContainSubstring("ooba"))
 ```
+### MatchRegexp
 
 ## Logical Matchers
 ### Not
@@ -48,7 +49,7 @@ Expect(t, false).To(Not(BeTrue()))
 ```
 
 ### BeAbove
-BeAboveMatcher accepts a numerical value. It succeeds if the actual is greater
+BeAboveMatcher accepts a float64. It succeeds if the actual is greater
 than the expected.
 
 ```go
@@ -56,7 +57,7 @@ Expect(t, 100).To(BeAbove(99))
 ```
 
 ### BeBelow
-BeBelowMatcher accepts a numerical value. It succeeds if the actual is
+BeBelowMatcher accepts a float64. It succeeds if the actual is
 less than the expected.
 
 ```go
@@ -95,20 +96,6 @@ Expect(t, nil).To(Not(HaveOccurred()))
 ```
 
 ## Channel Matchers
-### Always
-AlwaysMatcher matches by polling the child matcher until it returns an error.
-It will return an error the first time the child matcher returns an error.
-If the child matcher never returns an error, then it will return a nil.
-
-By default, the duration is 100ms with an interval of 10ms.
-
-```go
-isTrue := func() bool {
-  return true
-}
-Expect(t, isTrue).To(Always(BeTrue()))
-```
-
 ### Receive
 ReceiveMatcher only accepts a readable channel. It will error for anything else.
 It will attempt to receive from the channel but will not block.
@@ -155,6 +142,19 @@ Expect(t, "12345").To(HaveLen(5))
 ```
 
 ## Other Matchers
+### Always
+AlwaysMatcher matches by polling the child matcher until it returns an error.
+It will return an error the first time the child matcher returns an error.
+If the child matcher never returns an error, then it will return a nil.
+
+By default, the duration is 100ms with an interval of 10ms.
+
+```go
+isTrue := func() bool {
+  return true
+}
+Expect(t, isTrue).To(Always(BeTrue()))
+```
+
 ### Chain
 ### ViaPolling
-### MatchRegexp

--- a/matchers/README.md
+++ b/matchers/README.md
@@ -149,6 +149,7 @@ Expect(t, fooMap).To(HaveKey("foo"))
 ### HaveLen
 HaveLenMatcher accepts Strings, Slices, Arrays, Maps and Channels. It will
 succeed if the type has the specified length.
+
 ```go
 Expect(t, "12345").To(HaveLen(5))
 ```

--- a/matchers/be_above.go
+++ b/matchers/be_above.go
@@ -2,10 +2,13 @@ package matchers
 
 import "fmt"
 
+// BeAboveMatcher accepts a numerical value. It succeeds if the
+// actual is greater than the expected.
 type BeAboveMatcher struct {
 	expected float64
 }
 
+// BeAbove returns a BeAboveMatcher with the expected value.
 func BeAbove(expected float64) BeAboveMatcher {
 	return BeAboveMatcher{
 		expected: expected,

--- a/matchers/be_above.go
+++ b/matchers/be_above.go
@@ -2,7 +2,7 @@ package matchers
 
 import "fmt"
 
-// BeAboveMatcher accepts a numerical value. It succeeds if the
+// BeAboveMatcher accepts a float64. It succeeds if the
 // actual is greater than the expected.
 type BeAboveMatcher struct {
 	expected float64

--- a/matchers/be_below.go
+++ b/matchers/be_below.go
@@ -2,7 +2,7 @@ package matchers
 
 import "fmt"
 
-// BeBelowMatcher accepts a numerical value. It succeeds if the actual is
+// BeBelowMatcher accepts a float64. It succeeds if the actual is
 // less than the expected.
 type BeBelowMatcher struct {
 	expected float64

--- a/matchers/be_below.go
+++ b/matchers/be_below.go
@@ -2,10 +2,13 @@ package matchers
 
 import "fmt"
 
+// BeBelowMatcher accepts a numerical value. It succeeds if the actual is
+// less than the expected.
 type BeBelowMatcher struct {
 	expected float64
 }
 
+// BeBelow returns a BeBelowMatcher with the expected value.
 func BeBelow(expected float64) BeBelowMatcher {
 	return BeBelowMatcher{
 		expected: expected,

--- a/matchers/be_closed.go
+++ b/matchers/be_closed.go
@@ -5,9 +5,12 @@ import (
 	"reflect"
 )
 
-type BeClosedMatcher struct {
-}
+// BeClosedMatcher only accepts a readable channel.
+// It will error for anything else.
+// It will succeed if the channel is closed.
+type BeClosedMatcher struct{}
 
+// BeClosed returns a BeClosedMatcher
 func BeClosed() BeClosedMatcher {
 	return BeClosedMatcher{}
 }

--- a/matchers/be_false.go
+++ b/matchers/be_false.go
@@ -2,8 +2,10 @@ package matchers
 
 import "fmt"
 
+// BeFalseMatcher will succeed if actual is false.
 type BeFalseMatcher struct{}
 
+// BeFalse will return a BeFalseMatcher
 func BeFalse() BeFalseMatcher {
 	return BeFalseMatcher{}
 }

--- a/matchers/be_true.go
+++ b/matchers/be_true.go
@@ -2,8 +2,10 @@ package matchers
 
 import "fmt"
 
+// BeTrueMatcher will succeed if actual is true.
 type BeTrueMatcher struct{}
 
+// BeTrue will return a BeTrueMatcher
 func BeTrue() BeTrueMatcher {
 	return BeTrueMatcher{}
 }

--- a/matchers/contain_sub_string.go
+++ b/matchers/contain_sub_string.go
@@ -5,10 +5,14 @@ import (
 	"strings"
 )
 
+// ContainSubstringMatcher accepts a string and succeeds
+// if the actual string contains the expected string.
 type ContainSubstringMatcher struct {
 	substr string
 }
 
+// ContainSubstring returns a ContainSubstringMatcher with the
+// expected substring.
 func ContainSubstring(substr string) ContainSubstringMatcher {
 	return ContainSubstringMatcher{
 		substr: substr,

--- a/matchers/end_with.go
+++ b/matchers/end_with.go
@@ -5,10 +5,13 @@ import (
 	"strings"
 )
 
+// EndWithMatcher accepts a string and succeeds
+// if the actual string ends with the expected string.
 type EndWithMatcher struct {
 	suffix string
 }
 
+// EndWith returns an EndWithMatcher with the expected suffix.
 func EndWith(suffix string) EndWithMatcher {
 	return EndWithMatcher{
 		suffix: suffix,

--- a/matchers/equal.go
+++ b/matchers/equal.go
@@ -5,10 +5,12 @@ import (
 	"reflect"
 )
 
+// EqualMatcher performs a DeepEqual between the actual and expected.
 type EqualMatcher struct {
 	expected interface{}
 }
 
+// Equal returns an EqualMatcher with the expected value
 func Equal(expected interface{}) EqualMatcher {
 	return EqualMatcher{
 		expected: expected,

--- a/matchers/have_cap.go
+++ b/matchers/have_cap.go
@@ -5,10 +5,13 @@ import (
 	"reflect"
 )
 
+// This matcher works on Slices, Arrays, Maps and Channels and will succeed if the
+// type has the specified capacity.
 type HaveCapMatcher struct {
 	expected int
 }
 
+// HaveCap returns a HaveCapMatcher with the specified capacity
 func HaveCap(expected int) HaveCapMatcher {
 	return HaveCapMatcher{
 		expected: expected,

--- a/matchers/have_key.go
+++ b/matchers/have_key.go
@@ -5,10 +5,13 @@ import (
 	"reflect"
 )
 
+// HaveKeyMatcher accepts map types and will succeed if the map contains the
+// specified key.
 type HaveKeyMatcher struct {
 	key interface{}
 }
 
+// HaveKey returns a HaveKeyMatcher with the specified key.
 func HaveKey(key interface{}) HaveKeyMatcher {
 	return HaveKeyMatcher{
 		key: key,

--- a/matchers/have_len.go
+++ b/matchers/have_len.go
@@ -5,10 +5,13 @@ import (
 	"reflect"
 )
 
+// HaveLenMatcher accepts Strings, Slices, Arrays, Maps and Channels. It will
+// succeed if the type has the specified length.
 type HaveLenMatcher struct {
 	expected int
 }
 
+// HaveLen returns a HaveLenMatcher with the specified length.
 func HaveLen(expected int) HaveLenMatcher {
 	return HaveLenMatcher{
 		expected: expected,

--- a/matchers/have_occurred.go
+++ b/matchers/have_occurred.go
@@ -2,9 +2,11 @@ package matchers
 
 import "fmt"
 
+// HaveOccurredMatcher will succeed if the actual value is a non-nil error.
 type HaveOccurredMatcher struct {
 }
 
+// HaveOccurred returns a HaveOccurredMatcher
 func HaveOccurred() HaveOccurredMatcher {
 	return HaveOccurredMatcher{}
 }

--- a/matchers/not.go
+++ b/matchers/not.go
@@ -7,10 +7,12 @@ type Matcher interface {
 	Match(actual interface{}) (resultValue interface{}, err error)
 }
 
+// NotMatcher accepts a matcher and will succeed if the specified matcher fails.
 type NotMatcher struct {
 	child Matcher
 }
 
+// Not returns a NotMatcher with the specified child matcher.
 func Not(child Matcher) NotMatcher {
 	return NotMatcher{
 		child: child,

--- a/matchers/receive.go
+++ b/matchers/receive.go
@@ -5,9 +5,12 @@ import (
 	"reflect"
 )
 
-type ReceiveMatcher struct {
-}
+// ReceiveMatcher only accepts a readable channel. It will error for anything else.
+// It will attempt to receive from the channel but will not block.
+// It fails if the channel is closed.
+type ReceiveMatcher struct{}
 
+// Receive will return a ReceiveMatcher
 func Receive() ReceiveMatcher {
 	return ReceiveMatcher{}
 }

--- a/matchers/start_with.go
+++ b/matchers/start_with.go
@@ -5,10 +5,13 @@ import (
 	"strings"
 )
 
+// StartWithMatcher accepts a string and succeeds
+// if the actual string starts with the expected string.
 type StartWithMatcher struct {
 	prefix string
 }
 
+// StartWith returns a StartWithMatcher with the expected prefix.
 func StartWith(prefix string) StartWithMatcher {
 	return StartWithMatcher{
 		prefix: prefix,


### PR DESCRIPTION
Here is the first pass at some basic matcher docs.
It includes a README and godoc comments.

We still need to add documentation for the `Other Matchers` like `ViaPolling`, `Chain` and `MatchRegexp`

Resolves #5 