### PR TITLE
AfterEach: make AfterEach happen after t.Cleanup

### DIFF
--- a/onpar.go
+++ b/onpar.go
@@ -80,13 +80,6 @@ func (t *GroupTable[T, U, V]) Entry(name string, entry V) *GroupTable[T, U, V] {
 	return t
 }
 
-// FnEntry adds an entry to t that calls setup in order to get its entry value.
-// The value from the BeforeEach will be passed to setup, and then both values
-// will be passed to the table spec.
-func (t *GroupTable[T, U, V]) FnEntry(name string, setup func(U) V) *GroupTable[T, U, V] {
-	return t
-}
-
 // Onpar stores the state of the specs and groups
 type Onpar[T, U any] struct {
 	t TestRunner
@@ -386,9 +379,9 @@ func (s serialSpec[T]) name() string {
 
 func (s serialSpec[T]) run(t *testing.T, scope func() testScope[T]) {
 	sc := scope()
+	t.Cleanup(sc.after)
 	v := sc.before(t)
 	s.f(v)
-	sc.after()
 }
 
 type levelScope[T, U any] struct {

--- a/onpar_test.go
+++ b/onpar_test.go
@@ -150,6 +150,31 @@ func TestSingleNestedSpec(t *testing.T) {
 	}
 }
 
+func TestAfterEachAfterCleanup(t *testing.T) {
+	t.Parallel()
+
+	var lastRun string
+	t.Run("FakeSpecs", func(t *testing.T) {
+		o := onpar.BeforeEach(onpar.New(t), func(t *testing.T) *testing.T {
+			t.Cleanup(func() {
+				lastRun = "cleanup"
+			})
+			return t
+		})
+		defer o.Run()
+
+		o.AfterEach(func(t *testing.T) {
+			lastRun = "afterEach"
+		})
+
+		o.Spec("foo", func(t *testing.T) {})
+	})
+
+	if lastRun != "afterEach" {
+		t.Fatalf("expected afterEach to be the very last function to run, after all other test cleanup")
+	}
+}
+
 func TestInvokeFirstChildAndPeerSpec(t *testing.T) {
 	t.Parallel()
 	c := createScaffolding(t)


### PR DESCRIPTION
This updates our AfterEach logic to put AfterEach functions at the very end of test cleanup, so that AfterEach functions will be called after t.Cleanup functions.

This also removes a GroupTable method that was never implemented